### PR TITLE
fix the configuration according to the docs (PythonDocumentation.md)

### DIFF
--- a/examples/airquality.py
+++ b/examples/airquality.py
@@ -37,7 +37,7 @@ def control_LED(iaq):
         return 'RED'
 
 
-bme = BME68X(cnst.BME68X_I2C_ADDR_HIGH, 0)
+bme = BME68X(cnst.BME68X_I2C_ADDR_HIGH, 1)
 bme.set_sample_rate(bsec.BSEC_SAMPLE_RATE_LP)
 
 

--- a/examples/forced_mode.py
+++ b/examples/forced_mode.py
@@ -8,9 +8,9 @@ import bsecConstants as bsec
 from time import sleep
 
 print('TESTING FORCED MODE WITHOUT BSEC')
-bme = BME68X(cst.BME68X_I2C_ADDR_HIGH, 1)
+bme = BME68X(cst.BME68X_I2C_ADDR_HIGH, 0)
 # Configure sensor to measure at 320 degC for 100 millisec
-bme.set_heatr_conf(cst.BME68X_FORCED_MODE, 320, 100, cst.BME68X_ENABLE)
+bme.set_heatr_conf(cst.BME68X_ENABLE, 320, 100, cst.BME68X_FORCED_MODE)
 print(bme.get_data())
 sleep(3)
 print('\nTESTING FORCED MODE WITH BSEC')

--- a/examples/parallel_mode.py
+++ b/examples/parallel_mode.py
@@ -17,7 +17,7 @@ print(sensor.set_heatr_conf(cnst.BME68X_ENABLE,
 print(sensor.get_data())
 
 print('\n\nPARALLEL MODE WITH BSEC')
-sensor = BME68X(cnst.BME68X_I2C_ADDR_HIGH, 0)
+sensor = BME68X(cnst.BME68X_I2C_ADDR_HIGH, 1)
 sensor.set_sample_rate(bsec.BSEC_SAMPLE_RATE_HIGH_PERFORMANCE)
 
 


### PR DESCRIPTION
According to https://github.com/pi3g/bme68x-python-library/blob/main/PythonDocumentation.md, `get_bsec_data()` requires `use_bsec` to be set. If I understood the docs correctly, this and some other parameter were set incorrectly. I wonder if the examples worked as intended before. However, I tried to make them compatible with the docs.