### PR TITLE
Update bme68x_members in bme68xmodule.c

### DIFF
--- a/bme68xmodule.c
+++ b/bme68xmodule.c
@@ -259,6 +259,7 @@ static PyMemberDef bme68x_members[] = {
     {"op_mode", T_UBYTE, offsetof(BMEObject, op_mode), 0, "BME68X operation mode"},
     {"sample_count", T_UINT, offsetof(BMEObject, sample_count), 0, "number of data samples"},
     {"debug_mode", T_UBYTE, offsetof(BMEObject, debug_mode), 0, "enable/disable debug_mode"},
+    {NULL},
 };
 
 #ifdef BSEC


### PR DESCRIPTION
The final NULL entry in the bme68x_members array is needed for python API to detect last entry.
This issue seems to be compiler dependent, since the module already worked for most users. However adding this entry fixes pi3g/bme68x-python-library#11